### PR TITLE
Allow specifying target via Hostname (in addition to by IP)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,9 +68,9 @@ class instance extends InstanceBase {
 			{
 				type: 'textinput',
 				id: 'ip',
-				label: 'Target IP',
+				label: 'Target Device (IP or Hostname)',
 				width: 12,
-				regex: Regex.IP,
+				regex: Regex.HOSTNAME,
 			},
 			{
 				type: 'static-text',


### PR DESCRIPTION
change: Allow hostnames as well as IP address to define target device

Allow users to specify the target of the SMC module by either a fully qualified or local hostname, or by IP address. The existing control implementation is valid for either input without further changes, beyond input validation. 